### PR TITLE
Moved the help text from the getopts loop to its own function

### DIFF
--- a/salt-strap.sh
+++ b/salt-strap.sh
@@ -1,29 +1,35 @@
 #! /bin/bash
 
-INSTALL=false
-# Recieve command line arguments
+display_help_text () {
+	echo "
+    salt-strap is a quick bootstrap script used to set up a salt minion.
+
+	To install the salt minion, run the following
+		
+		./salt-strap.sh -i
+
+	It is expected that you provide the ip address of your salt master as follows.
+
+		./salt-strap.sh -m 10.0.70.19
+
+	If you are using salt's key identity feature, you can also provide it as follows
+	
+		./salt-strap.sh -m 10.0.70.19 -f ab:cd:ef:gh:ij:kl:mn:op:12:34:45:56:67:78:89
+
+	Ideally, you should run all steps at once
+	
+		./salt-strap.sh -i -m 10.0.70.19 -f ab:cd:ef:gh:ij:kl:mn:op:12:34:45:56:67:78:89
+
+	
+	Disclaimer: This script was written and tested for CentOS 7 servers
+	    "
+	exit
+}
+
+# Recieve command line arguments using getopts
 while getopts "hf:m:i" opt; do
   case ${opt} in
-    h ) echo "
-	    salt-strap is a quick bootstrap script used to set up a salt minion.
-
-	    	To install the salt minion, run the following
-			
-			./salt-strap.sh -i
-
-	    	It is expected that you provide the ip address of your salt master as follows.
-
-			./salt-strap.sh -m 10.0.70.19
-
-		If you are using salt's key identity feature, you can also provide it as follows
-		
-			./salt-strap.sh -m 10.0.70.19 -f ab:cd:ef:gh:ij:kl:mn:op:12:34:45:56:67:78:89
-
-		Ideally, you should run all steps at once
-		
-			./salt-strap.sh -i -m 10.0.70.19 -f ab:cd:ef:gh:ij:kl:mn:op:12:34:45:56:67:78:89
-	    "
-	    exit
+    h ) display_help_text 
       ;;
     f ) FINGER=$OPTARG
       ;;


### PR DESCRIPTION
I believe it's more readable to provide a display_help_text function, and it allows it to be called in multiple scenarios.